### PR TITLE
Added spell panel coloration and reduced code redundancy

### DIFF
--- a/CharacterItems.txt
+++ b/CharacterItems.txt
@@ -1,4 +1,0 @@
-P-Alarm
-P-Alter Self
-P-Animal Messenger
-<ENDSPELLS>

--- a/Resources/CharacterItems.txt
+++ b/Resources/CharacterItems.txt
@@ -1,3 +1,7 @@
+U-Abi Dalzim's Horrid Wilting
+U-Absorb Elements
+U-Acid Splash
+U-Aganazzar's Scorcher
 U-Alarm
 U-Animal Messenger
 <ENDSPELLS>

--- a/Resources/Preferences.txt
+++ b/Resources/Preferences.txt
@@ -1,2 +1,3 @@
 <CFOC>1
 <WiSi>1.5
+<SBCP>true

--- a/src/files/FileSystem.java
+++ b/src/files/FileSystem.java
@@ -109,12 +109,9 @@ public class FileSystem {
 	
 	/**
 	 * Saves userPreferences data
-	 * @param prefs String array of user preferences
-	 * Index 0 - Center Frames on Call setting
-	 * Index 1 - User's window size setting
 	 * @return {@code boolean} whether the save was successful
 	 */
-	public static boolean saveUserPref(String[] prefs)		//User Prefs
+	public static boolean saveUserPref()		//User Prefs
 	{
 		System.out.println("Saving preferences...");
 		String tempFile = "tmp.txt";
@@ -128,6 +125,8 @@ public class FileSystem {
 			bw.write("<CFOC>" + Settings.getCenterFrames());
 			bw.newLine();
 			bw.write("<WiSi>" + Settings.getScaleAdjustment());
+			bw.newLine();
+			bw.write("<SBCP>" + Settings.getSBColor());
 			bw.close();
 			
 			File oldFile = new File(prefPath);
@@ -542,6 +541,7 @@ public class FileSystem {
 	 * @return an array of the user's settings
 	 * Index 0 - Window centering behavior
 	 * Index 1 - Window resize value
+	 * Index 2 - SpellBrowser coloration value
 	 * @throws IOException
 	 */
 	public static String[] loadPreferences() throws IOException
@@ -549,6 +549,7 @@ public class FileSystem {
 		String[] contents = read(prefPath);
 		contents[0] = contents[0].substring(6);
 		contents[1] = contents[1].substring(6);
+		contents[2] = contents[2].substring(6);
 		return contents;
 	}
 	

--- a/src/guiPanels/SpellBrowserPanel.java
+++ b/src/guiPanels/SpellBrowserPanel.java
@@ -17,6 +17,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import java.awt.BorderLayout;
 import java.awt.Font;
+import java.awt.Color;
 
 @SuppressWarnings("serial")
 public class SpellBrowserPanel extends JPanel {
@@ -31,6 +32,17 @@ public class SpellBrowserPanel extends JPanel {
 		JLabel lblName = new JLabel("   " + spell.getName());
 		lblName.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 		add(lblName, BorderLayout.CENTER);
+		
+		if(Settings.getSBColor())
+		{
+			int color = 255 - (spell.getLevel() * 28);
+			setBackground(new Color(color, color, color));
+			if (color < 100)
+			{
+				lblName.setForeground(Color.WHITE);
+			}
+			
+		}
 		
 		JPanel panel = new JPanel();
 		add(panel, BorderLayout.EAST);

--- a/src/mainGUI/CustomSpellAdder.java
+++ b/src/mainGUI/CustomSpellAdder.java
@@ -16,6 +16,7 @@ import userData.Settings;
 import javax.swing.JScrollPane;
 import java.awt.GridLayout;
 import java.awt.Image;
+import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ContainerAdapter;
@@ -33,20 +34,18 @@ public class CustomSpellAdder extends JFrame {
 	private static final long serialVersionUID = 1L;
 	private JPanel contentPane;
 	private JPanel panelSpells;
+	
+	private JButton btnAddSpell;
+	private JButton btnSave;
 
 	/**
 	 * Create the frame.
 	 */
 	public CustomSpellAdder() {
-		double scaleFactor = Settings.getResizeFactor();
-		//double scaleFactor = 1;
-		
 		setResizable(false);
 		setTitle("Custom Spells");
 		setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
-		setBounds(100, 100, 
-				(int)(331 * scaleFactor), 
-				(int)(300 * scaleFactor));
+		
 		contentPane = new JPanel();
 		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 		contentPane.setLayout(new BorderLayout(0, 5));
@@ -89,8 +88,7 @@ public class CustomSpellAdder extends JFrame {
 		contentPane.add(panel, BorderLayout.SOUTH);
 		panel.setLayout(new BorderLayout(0, 0));
 		
-		JButton btnAddSpell = new JButton("Add Spell");
-		btnAddSpell.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
+		btnAddSpell = new JButton("Add Spell");
 		panel.add(btnAddSpell, BorderLayout.EAST);
 		btnAddSpell.addActionListener(new ActionListener() {
 			@Override
@@ -101,15 +99,33 @@ public class CustomSpellAdder extends JFrame {
 			}
 		});
 		
-		JButton btnNewButton = new JButton("Save");
-		btnNewButton.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
-		panel.add(btnNewButton, BorderLayout.WEST);
-		btnNewButton.addActionListener(new ActionListener() {
+		btnSave = new JButton("Save");
+		panel.add(btnSave, BorderLayout.WEST);
+		btnSave.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				saveSpells();
 			}
 		});
 
+		refresh();
+		
+		Point USW = UserSpellWindow.getWindowLocation();
+		setLocation(USW.x + 30, USW.y + 30);
+	}
+	
+	/**
+	 * Refreshes the scaling and content of the window
+	 */
+	public void refresh() {
+		double scaleFactor = Settings.getResizeFactor();
+		
+		setBounds(getX(), getY(), 
+				(int)(331 * scaleFactor), 
+				(int)(300 * scaleFactor));
+		
+		btnAddSpell.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
+		
+		btnSave.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 	}
 	
 	/**
@@ -142,6 +158,7 @@ public class CustomSpellAdder extends JFrame {
 	public void reset()
 	{
 		panelSpells.removeAll();
+		refresh();
 		
 		for (Spell spell : Spell_List.getCustomSpells())
 		{

--- a/src/mainGUI/SpellBrowser.java
+++ b/src/mainGUI/SpellBrowser.java
@@ -2,6 +2,8 @@ package mainGUI;
 
 import java.awt.Font;
 import java.awt.Image;
+import java.awt.Point;
+
 import javax.swing.ImageIcon;
 
 import javax.swing.JFrame;
@@ -39,19 +41,17 @@ public class SpellBrowser extends JFrame {
 	private JComboBox<Object> comboBoxSchools;
 	private JPanel panelSpells;
 	private UserSpellWindow uswParent;
+	
+	private static SpellBrowser self;
 
 	/**
 	 * Create the frame.
 	 */
 	public SpellBrowser(UserSpellWindow parent) {
-		double scaleFactor = Settings.getResizeFactor();
 		setResizable(false);
 		setTitle("Add spell");
 		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-		setBounds((int)(100 * scaleFactor),
-				(int)(100 * scaleFactor),
-				(int)(384 * scaleFactor),
-				(int)(413 * scaleFactor) - (int)(20 * (scaleFactor - 1)));
+		
 		contentPane = new JPanel();
 		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 		setContentPane(contentPane);
@@ -67,11 +67,6 @@ public class SpellBrowser extends JFrame {
 		}
         
 		scrollPane = new JScrollPane();
-		scrollPane.setBounds((int)(10 * scaleFactor),
-				(int)(69 * scaleFactor),
-				(int)(358 * scaleFactor),
-				(int)(304 * scaleFactor));
-		scrollPane.getVerticalScrollBar().setUnitIncrement((int)(17 * scaleFactor) + 6);
 		contentPane.add(scrollPane);
 		
 		panelSpells = new JPanel();
@@ -79,7 +74,6 @@ public class SpellBrowser extends JFrame {
 		panelSpells.setLayout(new BoxLayout(panelSpells, BoxLayout.Y_AXIS));
 		
 		searchField = new JTextField();
-		searchField.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 		searchField.getDocument().addDocumentListener(new DocumentListener() {
 			@Override
 			public void changedUpdate(DocumentEvent arg0) {
@@ -95,19 +89,10 @@ public class SpellBrowser extends JFrame {
 				refresh();
 			}
 		});
-		searchField.setBounds((int)(51 * scaleFactor),
-				(int)(11 * scaleFactor),
-				(int)(197 * scaleFactor),
-				(int)(20 * scaleFactor));
 		contentPane.add(searchField);
 		searchField.setColumns(10);
 		
 		lblSearch = new JLabel("Search:");
-		lblSearch.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
-		lblSearch.setBounds((int)(10 * scaleFactor),
-				(int)(14 * scaleFactor),
-				(int)(46 * scaleFactor),
-				(int)(14 * scaleFactor));
 		contentPane.add(lblSearch);
 		
 		String[] levelOptions = {"All Levels", "Cantrips", "Level 1", 
@@ -119,11 +104,6 @@ public class SpellBrowser extends JFrame {
 				refresh();
 			}
 		});
-		comboBoxLevels.setBounds((int)(12 * scaleFactor),
-				(int)(38 * scaleFactor),
-				(int)(110 * scaleFactor),
-				(int)(20 * scaleFactor));
-		comboBoxLevels.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 		contentPane.add(comboBoxLevels);
 		
 		String[] searchOptions = {"Name", "Description"};
@@ -133,11 +113,6 @@ public class SpellBrowser extends JFrame {
 				refresh();
 			}
 		});
-		comboBoxOption.setBounds((int)(258 * scaleFactor),
-				(int)(11 * scaleFactor),
-				(int)(110 * scaleFactor),
-				(int)(20 * scaleFactor));
-		comboBoxOption.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 		contentPane.add(comboBoxOption);
 		
 		ArrayList<String> classOptions = new ArrayList<String>();
@@ -152,11 +127,6 @@ public class SpellBrowser extends JFrame {
 				refresh();
 			}
 		});
-		comboBoxClasses.setBounds((int)(134 * scaleFactor),
-				(int)(38 * scaleFactor),
-				(int)(110 * scaleFactor),
-				(int)(20 * scaleFactor));
-		comboBoxClasses.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 		contentPane.add(comboBoxClasses);
 		
 		comboBoxSchools = new JComboBox<Object>(new String[]
@@ -167,14 +137,13 @@ public class SpellBrowser extends JFrame {
 				refresh();
 			}
 		});
-		comboBoxSchools.setBounds((int)(256 * scaleFactor),
-				(int)(38 * scaleFactor),
-				(int)(110 * scaleFactor),
-				(int)(20 * scaleFactor));
-		comboBoxSchools.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 		contentPane.add(comboBoxSchools);
 		
+		self = this;
 		refresh();
+		
+		Point USW = UserSpellWindow.getWindowLocation();
+		setLocation(USW.x + 30, USW.y + 30);
 	}
 	
 	/**
@@ -218,6 +187,7 @@ public class SpellBrowser extends JFrame {
 				(int)(69 * scaleFactor),
 				(int)(358 * scaleFactor),
 				(int)(304 * scaleFactor));
+		scrollPane.getVerticalScrollBar().setUnitIncrement((int)(scaleFactor*(24.0/5.0) + 2));
 		
 		searchField.setFont(new Font("Tahoma", Font.PLAIN, (int)(11 * scaleFactor)));
 		searchField.setBounds((int)(51 * scaleFactor),
@@ -257,6 +227,13 @@ public class SpellBrowser extends JFrame {
 		
 		repaint();
 		revalidate();
+	}
+	
+	/**
+	 * Resets the state of the window
+	 */
+	public static void windowRefresh(){
+		self.refresh();
 	}
 	
 	/**

--- a/src/mainGUI/UserSpellWindow.java
+++ b/src/mainGUI/UserSpellWindow.java
@@ -19,6 +19,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.ImageIcon;
 import java.awt.Image;
+import java.awt.Point;
 import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.awt.event.ActionListener;
@@ -65,11 +66,16 @@ public class UserSpellWindow extends JFrame {
 			}
 		});
 		
+		window = this;
+		this.setLocation(100, 100);
+		
 		Settings.addResizeListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				draw();
 				browser.refresh();
+				settings.refresh();
+				customSpells.refresh();
 			}
 		});
 		
@@ -92,10 +98,8 @@ public class UserSpellWindow extends JFrame {
 		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 		setContentPane(contentPane);
 		contentPane.setLayout(null);
-		window = this;
 		
 		draw(); //draws the elements of the window
-		this.setLocation(100, 100);
 	}
 	
 	/**
@@ -107,7 +111,7 @@ public class UserSpellWindow extends JFrame {
 		
 		setBounds(getX(), getY(),
 				(int)(641 * scaleFactor),
-				(int)(420 * scaleFactor));
+				(int)(390 * scaleFactor) + 40);
 		
 		contentPane.removeAll();
 		
@@ -129,6 +133,8 @@ public class UserSpellWindow extends JFrame {
 		JScrollPane scrollPaneLevel7 = new JScrollPane();
 		JScrollPane scrollPaneLevel8 = new JScrollPane();
 		JScrollPane scrollPaneLevel9 = new JScrollPane();
+		
+		scrollPaneAllSpells.getHorizontalScrollBar().setUnitIncrement(25);
 		
 		tabbedPane.addTab("All spells", null, scrollPaneAllSpells, null);
 		tabbedPane.addTab("Cantrips", null, scrollPaneCantrips, null);
@@ -264,14 +270,14 @@ public class UserSpellWindow extends JFrame {
 		mntmClearSpells.setFont(new Font("Segoe UI", Font.PLAIN, (int)(11 * scaleFactor)));
 		mnMenu.add(mntmClearSpells);
 		
-		mntmPreferences = new JMenuItem("Preferences");
+		mntmPreferences = new JMenuItem("Settings");
 		mntmPreferences.setFont(new Font("Segoe UI", Font.PLAIN, (int)(11 * scaleFactor)));
-		mntmPreferences.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.CTRL_MASK));
+		mntmPreferences.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_MASK));
 		mnMenu.add(mntmPreferences);
 		mntmPreferences.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				if (!settings.isVisible()) {
-					settings.reset();
+					settings.refresh();
 					settings.setVisible(true);
 				}
 				settings.toFront();
@@ -308,6 +314,8 @@ public class UserSpellWindow extends JFrame {
 				browser.toFront();
 				customSpells.setVisible(true);
 				customSpells.toFront();
+				settings.setVisible(true);
+				settings.toFront();
 			}
 		});
 		
@@ -368,7 +376,13 @@ public class UserSpellWindow extends JFrame {
 		}
 	}
 	
-
+	/**
+	 * Returns the location of the window
+	 * @return {@code Point} UserSpellWindow's location
+	 */
+	public static Point getWindowLocation() {
+		return window.getLocation(null);
+	}
 	
 	/**
 	 * Removes a SpellCard from the menu and the User's spellbook

--- a/src/secondaryGUI/SettingsWindow.java
+++ b/src/secondaryGUI/SettingsWindow.java
@@ -14,6 +14,15 @@ import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import java.awt.Font;
 import java.awt.Image;
+import java.awt.Point;
+
+import javax.swing.border.LineBorder;
+
+import mainGUI.UserSpellWindow;
+
+import java.awt.Color;
+import javax.swing.JCheckBox;
+import java.awt.GridLayout;
 
 @SuppressWarnings("serial")
 public class SettingsWindow extends JFrame {
@@ -22,8 +31,13 @@ public class SettingsWindow extends JFrame {
 	private JComboBox<Object> comboBoxCentering;
 	private JComboBox<Object> comboBoxSize;
 	
+	private JPanel panelSpellBrowser;
+	private JLabel lblSBrowser;
+	private JCheckBox chckbxColor;
+	
 	private JLabel lblResizeValue;
 	private JButton btnSave;
+	private JButton btnSaveQuit;
 	private JLabel lblWindowPositioningSetting;
 
 	/**
@@ -33,10 +47,7 @@ public class SettingsWindow extends JFrame {
 		setResizable(false);
 		setTitle("Settings");
 		setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
-		double scaleFactor = Settings.getResizeFactor();
-		setBounds(100, 100, 
-				(int)(336*scaleFactor), 
-				(int)(180*scaleFactor) - (int)(27 * (scaleFactor-1)));
+
 		contentPane = new JPanel();
 		contentPane.setBorder(new EmptyBorder(5, 5, 5, 5));
 		setContentPane(contentPane);
@@ -50,92 +61,77 @@ public class SettingsWindow extends JFrame {
 		}
 		
 		lblWindowPositioningSetting = new JLabel("Window Positioning Behavior");
-		lblWindowPositioningSetting.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
-		lblWindowPositioningSetting.setBounds((int)(10*scaleFactor), 
-				(int)(11*scaleFactor), 
-				(int)(250*scaleFactor), 
-				(int)(14*scaleFactor));
 		contentPane.add(lblWindowPositioningSetting);
 		
-		String[] centeringOptions = {"Do nothing on window call",
+		String[] centeringOptions = {"Do not move window on call",
 				"Only center windows when first appear",
 				"Center windows whenever button is clicked"};
-		
 		comboBoxCentering = new JComboBox<Object>(centeringOptions);
-		comboBoxCentering.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
-		comboBoxCentering.setSelectedIndex(Settings.getCenterFrames());
-		comboBoxCentering.setBounds((int)(10*scaleFactor), 
-				(int)(31*scaleFactor), 
-				(int)(310*scaleFactor), 
-				(int)(20*scaleFactor));
 		contentPane.add(comboBoxCentering);
 		
-		btnSave = new JButton("Save Preferences");
-		btnSave.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
-		btnSave.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				Settings.setCenterFrames(comboBoxCentering.getSelectedIndex());
-				Settings.setScaleAdjustment(0.75 + (1 * comboBoxSize.getSelectedIndex()*0.25));
-				Settings.savePreferences();
-				reset();
-			}
-		});
-		btnSave.setBounds((int)(176*scaleFactor), 
-				(int)(120*scaleFactor), 
-				(int)(144*scaleFactor), 
-				(int)(23*scaleFactor));
-		contentPane.add(btnSave);
-		
 		lblResizeValue = new JLabel("Window Size");
-		lblResizeValue.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
-		lblResizeValue.setBounds((int)(10*scaleFactor), 
-				(int)(62*scaleFactor), 
-				(int)(250*scaleFactor), 
-				(int)(14*scaleFactor));
 		contentPane.add(lblResizeValue);
 		
 		String[] sizeOptions = {"Very Small", "Small", "Default", "Large", "Very Large"};
 		comboBoxSize = new JComboBox<Object>(sizeOptions);
-		comboBoxSize.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
-		comboBoxSize.setSelectedIndex(0);
-		comboBoxSize.setBounds((int)(10*scaleFactor), 
-				(int)(82*scaleFactor), 
-				(int)(310*scaleFactor), 
-				(int)(20*scaleFactor));
 		contentPane.add(comboBoxSize);
+		
+		lblSBrowser = new JLabel("Spell Browser Settings");
+		contentPane.add(lblSBrowser);
+		
+		panelSpellBrowser = new JPanel();
+		panelSpellBrowser.setBorder(new LineBorder(new Color(150, 150, 150), 1, true));
+		contentPane.add(panelSpellBrowser);
+		panelSpellBrowser.setLayout(new GridLayout(0, 1, 0, 0));
+		
+		chckbxColor = new JCheckBox("Use color to distinguish spell level");
+		panelSpellBrowser.add(chckbxColor);
+		
+		btnSave = new JButton("Save Preferences");
+		btnSave.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				Settings.setCenterFrames(comboBoxCentering.getSelectedIndex());
+				Settings.setScaleAdjustment(0.75 + (1 * comboBoxSize.getSelectedIndex()*0.25));
+				Settings.setSBColor(chckbxColor.isSelected());
+				Settings.savePreferences();
+				refresh();
+			}
+		});
+		contentPane.add(btnSave);
+		
+		btnSaveQuit = new JButton("Save & Close");
+		btnSaveQuit.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent arg0) {
+				Settings.setCenterFrames(comboBoxCentering.getSelectedIndex());
+				Settings.setScaleAdjustment(0.75 + (1 * comboBoxSize.getSelectedIndex()*0.25));
+				Settings.setSBColor(chckbxColor.isSelected());
+				Settings.savePreferences();
+				setVisible(false);
+			}
+		});
+		contentPane.add(btnSaveQuit);
+		
+		refresh();
+		Point USW = UserSpellWindow.getWindowLocation();
+		setLocation(USW.x + 30, USW.y + 30);
 	}
 	
 	/**
 	 * Refreshes the window to make sure it reflects current information
 	 */
-	public void reset(){
+	public void refresh(){
+		//Reset Values
 		comboBoxCentering.setSelectedIndex(Settings.getCenterFrames());
-		switch ((int)(Settings.getScaleAdjustment()*4)) //Have to multiply scale by 4 to get ints
-		{
-			case 3:
-				comboBoxSize.setSelectedIndex(0);
-				break;
-			case 4:
-				comboBoxSize.setSelectedIndex(1);
-				break;
-			case 5:
-				comboBoxSize.setSelectedIndex(2);
-				break;
-			case 6:
-				comboBoxSize.setSelectedIndex(3);
-				break;
-			case 7:
-				comboBoxSize.setSelectedIndex(4);
-				break;
-			default:
-				comboBoxSize.setSelectedIndex(2);
-		}
+		comboBoxSize.setSelectedIndex((int)(Settings.getScaleAdjustment()*4) - 3);
+		chckbxColor.setSelected(Settings.getSBColor());
 		
+		//Get scale factor
 		double scaleFactor = Settings.getResizeFactor();
 		
+		//Resize all components
 		setBounds(getX(), getY(),
 				(int)(336*scaleFactor), 
-				(int)(180*scaleFactor) - (int)(27 * (scaleFactor-1)));
+				(int)(242*scaleFactor) - (int)(37 * (scaleFactor-1)));
 		
 		lblWindowPositioningSetting.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
 		lblWindowPositioningSetting.setBounds((int)(10*scaleFactor), 
@@ -161,11 +157,29 @@ public class SettingsWindow extends JFrame {
 				(int)(310*scaleFactor), 
 				(int)(20*scaleFactor));
 		
+		lblSBrowser.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
+		lblSBrowser.setBounds((int)(10*scaleFactor), 
+				(int)(113*scaleFactor), 
+				(int)(250*scaleFactor), 
+				(int)(14*scaleFactor));
+		
+		panelSpellBrowser.setBounds((int)(10*scaleFactor), 
+				(int)(132*scaleFactor), 
+				(int)(310*scaleFactor), 
+				(int)(35*scaleFactor));
+		
+		chckbxColor.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
+		
 		btnSave.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
-		btnSave.setBounds((int)(176*scaleFactor), 
-				(int)(120*scaleFactor), 
+		btnSave.setBounds((int)(10*scaleFactor), 
+				(int)(180*scaleFactor), 
 				(int)(144*scaleFactor), 
 				(int)(23*scaleFactor));
+		
+		btnSaveQuit.setFont(new Font("Tahoma", Font.PLAIN, (int)(11*scaleFactor)));
+		btnSaveQuit.setBounds((int)(176*scaleFactor),
+				(int)(180*scaleFactor),
+				(int)(144*scaleFactor),
+				(int)(23*scaleFactor));
 	}
-
 }

--- a/src/userData/Settings.java
+++ b/src/userData/Settings.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 
 import files.FileSystem;
 import mainGUI.SpellBookLauncher;
+import mainGUI.SpellBrowser;
 
 public class Settings {
 	
@@ -21,6 +22,10 @@ public class Settings {
 	 * User determined window scaling
 	 */
 	private static double scaleAdjustment;
+	/**
+	 * Whether spellbrowser panels should be colored to reflect spell level
+	 */
+	private static boolean SBColor;
 	
 	private static ArrayList<ActionListener> resizeObservers = 
 			new ArrayList<ActionListener>();
@@ -35,6 +40,7 @@ public class Settings {
 			centerFrames = Integer.parseInt(preferences[0]);
 			scaleFactor = SpellBookLauncher.getScale();
 			scaleAdjustment = Double.parseDouble(preferences[1]);
+			SBColor = preferences[2].equals("true");
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -46,9 +52,7 @@ public class Settings {
 	 */
 	public static void savePreferences()
 	{
-		String[] preferences = {centerFrames + "", 
-				scaleAdjustment + ""};
-		FileSystem.saveUserPref(preferences);
+		FileSystem.saveUserPref();
 	}
 	
 	/**
@@ -104,6 +108,30 @@ public class Settings {
 			scaleAdjustment = adjustment;
 			notifyResizeObservers();
 		}
+	}
+	
+	/**
+	 * Sets whether SpellBrowser panels should be colored 
+	 * to reflect the spell's level
+	 * @param colorPanels {@code boolean}
+	 */
+	public static void setSBColor(boolean colorPanels)
+	{
+		if (SBColor != colorPanels) {
+			SBColor = colorPanels;
+			SpellBrowser.windowRefresh();
+		}
+	}
+	
+	/**
+	 * Returns whether SpellBrowser panels should be colored 
+	 * to reflect the spell's level
+	 * @return {@code boolean} Returns <em>true</em> if the 
+	 * coloration is turned on
+	 */
+	public static boolean getSBColor()
+	{
+		return SBColor;
 	}
 	
 	/**


### PR DESCRIPTION
There is now an option in settings to have the spells in the spell
browser darken in relation to their level, allowing you to tell
approximately what level a spell is just by looking at it. I also
changed a mechanism of drawing windows. Rather than have drawing done
during initialization and refresh, the constructor calls the refresh
method to set component sizes. I also made it so that the custom spell
creator window behaved with resize calls

Minor Changes:
- Fixed erronious scaling on UserSpellWindow
- Fixed scroll bar speed on USW and SB
- Changed "Show all windows" to also pull up settings
- Changed "Preferences" menu item to "Settings" for consistency. Also
changed its shortcut to "Ctrl + D"
- Split "Save and Quit" in Settings into "Save Preferences" and "Save &
Close"